### PR TITLE
Set train encoder to True for skill chain config

### DIFF
--- a/config/experiments/ver_goat_skill_chain.yaml
+++ b/config/experiments/ver_goat_skill_chain.yaml
@@ -69,7 +69,7 @@ habitat_baselines:
     ddppo:
       sync_frac: 0.6
       distrib_backend: NCCL
-      train_encoder: False
+      train_encoder: True
 
       # Model parameters
       backbone: resnet50_clip_avgpool


### PR DESCRIPTION
We need to set `train_encoder: True` otherwise the high-level policy tries to load a checkpoint into `*.visual_encoder` which does not exist.